### PR TITLE
Trigger gameover when light <= 0 instead of == 0

### DIFF
--- a/Sun Son/Assets/Scenes/Levels.meta
+++ b/Sun Son/Assets/Scenes/Levels.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 987bbcf98748bd24e84219a2ec49538f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Sun Son/Assets/Scenes/Levels/Caves Level.meta
+++ b/Sun Son/Assets/Scenes/Levels/Caves Level.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0c01c811b9336d84caf6aca9ddacdcb8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Sun Son/Assets/Scripts/UIController.cs
+++ b/Sun Son/Assets/Scripts/UIController.cs
@@ -23,7 +23,7 @@ public class UIController : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        if (_player.getCurrentLightPoints() == 0) {
+        if (_player.getCurrentLightPoints() <= 0) {
             _gameOver.SetActive(true);
         }
         _lightBar.SetLightPoints(_player.getCurrentLightPoints());


### PR DESCRIPTION
Light could go below 0 when a massive amount of damage was taken
so this will ensure Game Over happens whenever player dies